### PR TITLE
Better email validation

### DIFF
--- a/zenduty/helpers.go
+++ b/zenduty/helpers.go
@@ -63,8 +63,8 @@ func ValidateUUID() schema.SchemaValidateDiagFunc {
 }
 
 func isEmailValid(e string) bool {
-	emailRegex := regexp.MustCompile(`^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`)
-	return emailRegex.MatchString(e)
+	emailAddress, err := mail.ParseAddress(e)
+	return err == nil && emailAddress.Address == e
 }
 
 func ValidateEmail() schema.SchemaValidateDiagFunc {


### PR DESCRIPTION
The current email validation has a regex that checks domains pattern, specifically that the TLD is between 2 to 4 characters
There are many valid TLD that are longer than 4 chars - https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains
Also, there is a built in std lib in go for mail parsing based on RFS 5322 - https://pkg.go.dev/net/mail#ParseAddress

This change allow any valid email to work