### PR TITLE
Allow owner user

### DIFF
--- a/docs/resources/zenduty_user.md
+++ b/docs/resources/zenduty_user.md
@@ -34,7 +34,7 @@ resource "zenduty_user" "demouser" {
 * `first_name` (Required) - Firstname of the user
 * `last_name` (Required) - Lastname of the user
 * `team` (Required) - Unique of the team to which the user is to be invited
-* `role` (Optional) - Role of the user (`2` for admin , `3` for user) set to `3` while creation.
+* `role` (Optional) - Role of the user (`1` for owner, `2` for admin , `3` for user) set to `3` while creation.
 
 ## Attributes Reference
 

--- a/zenduty/resource_user.go
+++ b/zenduty/resource_user.go
@@ -42,7 +42,7 @@ func resourceUser() *schema.Resource {
 			"role": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.IntBetween(2, 3),
+				ValidateFunc: validation.IntBetween(1, 3),
 				Default:      3,
 			},
 		},


### PR DESCRIPTION
Currently the `role` in `user` allow only 2/3 values
When creating account in Zenduty, the first user is `Owner` which is value of 1
There is no way to import that user into a resource
This PR fixes that and allow value of 1 in the `role`