### PR TITLE
Grant workflow token write access for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
   push:
     tags:
       - "v*"
+# Releases need write access to the repo contents; the org default token is read-only.
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The v2.0.0 release run failed at the publish step:

```
release failed: PATCH .../releases/370540632: 403 Resource not accessible by integration
```

The org/repo default workflow permissions are now read-only, so the automatic `GITHUB_TOKEN` can no longer create or update releases. Previous releases (up to v1.0.6) ran while the default was still "Read and write".

## What

Adds an explicit `permissions: contents: write` block to the release workflow. This grants write access only to this workflow regardless of the org default, which is the recommended fix (and what HashiCorp's current provider scaffolding ships with) instead of restoring repo-wide write defaults or using a PAT.

## After merging

To publish v2.0.0: delete the manually created v2.0.0 release (keep the tag), then re-run the release workflow so GoReleaser creates the release with the signed artifacts the Terraform Registry expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)